### PR TITLE
Fix compatibility issue with Openfire 4.9.0

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -43,6 +43,12 @@
 <h1>Onesocialweb Plugin Changelog
 </h1>
 
+<p><b>0.7.0</b> -- (tbd)</p>
+<ul>
+    <li>Now requires Openfire 4.8.0</li>
+    <li>Fixes <a href="https://github.com/igniterealtime/openfire-galene-plugin/issues/6">issue #6</a>: Fix compatibility issue with Openfire 4.9.0</li>
+</ul>
+
 <p><b>0.6</b> -- April 1st, 2010</p>
 <ul>
     <li>First public release.</li>

--- a/plugin.xml
+++ b/plugin.xml
@@ -8,6 +8,6 @@
    <url>http://onesocialweb.org</url>
    <version>${pom.version}</version>
    <date>${openfire-plugin.build.date}</date>
-   <minServerVersion>3.7.1</minServerVersion>
+   <minServerVersion>4.8.0</minServerVersion>
    <licenseType>apache</licenseType>
 </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.7.1</version>
+        <version>4.8.0</version>
     </parent>
 	
   <groupId>org.onesocialweb</groupId>

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 <img src="https://igniterealtime.github.io/openfire-osw-plugin/onesocialweb.png" /> 
 
-This is the revived onesocialweb project for Openfire 4.7.1+. It includes: 
+This is the revived onesocialweb project for Openfire 4.8.0+. It includes: 
 
 - the Openfire plugin
 - the web client which can be accessed with https://your-server:7443/osw.

--- a/src/java/org/onesocialweb/openfire/OswPlugin.java
+++ b/src/java/org/onesocialweb/openfire/OswPlugin.java
@@ -17,6 +17,7 @@
 package org.onesocialweb.openfire;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
 import java.util.Hashtable;
@@ -208,7 +209,7 @@ public class OswPlugin implements Plugin {
 			}
 		}
 
-		String logFile = JiveGlobals.getHomeDirectory() + "/logs/osw_openjpa.log";
+		Path logFile = JiveGlobals.getHomePath().resolve("logs").resolve("osw_openjpa.log");
 		String debugLevel = "INFO";
 		
 		if (Log.isDebugEnabled()) {	
@@ -221,7 +222,7 @@ public class OswPlugin implements Plugin {
 		connProperties.put("openjpa.ConnectionUserName", username);
 		connProperties.put("openjpa.ConnectionPassword", password);
 
-		connProperties.put("openjpa.Log", "DefaultLevel=" + debugLevel + ", Tool=" + debugLevel + ", SQL=" + debugLevel + ", File=" + logFile);
+		connProperties.put("openjpa.Log", "DefaultLevel=" + debugLevel + ", Tool=" + debugLevel + ", SQL=" + debugLevel + ", File=" + logFile.toAbsolutePath());
 		connProperties.put("openjpa.jdbc.SynchronizeMappings", "buildSchema(ForeignKeys=true)");
 		connProperties.put("openjpa.Multithreaded", "true");
 		

--- a/src/java/org/onesocialweb/openfire/handler/MessageEventInterceptor.java
+++ b/src/java/org/onesocialweb/openfire/handler/MessageEventInterceptor.java
@@ -75,9 +75,9 @@ public class MessageEventInterceptor implements PacketInterceptor {
 				return;
 			}
 
-			// We only care for messaes to local users
+			// We only care for messages to local users
 			if (!server.isLocal(toJID)
-					|| !server.getUserManager().isRegisteredUser(toJID)) {
+					|| !server.getUserManager().isRegisteredUser(toJID, false)) {
 				return;
 			}
 

--- a/src/java/org/onesocialweb/openfire/handler/activity/ActivityDeleteHandler.java
+++ b/src/java/org/onesocialweb/openfire/handler/activity/ActivityDeleteHandler.java
@@ -66,7 +66,7 @@ public class ActivityDeleteHandler  extends PEPCommandHandler {
 			}
 			
 			// Only a local user can delete an activity to his stream
-			if (!userManager.isRegisteredUser(sender.getNode())) {
+			if (!userManager.isRegisteredUser(sender, false)) {
 				IQ result = IQ.createResultIQ(packet);
 				result.setChildElement(packet.getChildElement().createCopy());
 				result.setError(PacketError.Condition.not_authorized);

--- a/src/java/org/onesocialweb/openfire/handler/activity/ActivityPublishHandler.java
+++ b/src/java/org/onesocialweb/openfire/handler/activity/ActivityPublishHandler.java
@@ -83,7 +83,7 @@ public class ActivityPublishHandler extends PEPCommandHandler {
 			}
 			
 			// Only a local user can publish an activity to his stream
-			if (!userManager.isRegisteredUser(sender.getNode())) {
+			if (!userManager.isRegisteredUser(sender, false)) {
 				IQ result = IQ.createResultIQ(packet);
 				result.setChildElement(packet.getChildElement().createCopy());
 				result.setError(PacketError.Condition.not_authorized);

--- a/src/java/org/onesocialweb/openfire/handler/activity/ActivityQueryHandler.java
+++ b/src/java/org/onesocialweb/openfire/handler/activity/ActivityQueryHandler.java
@@ -70,7 +70,7 @@ public class ActivityQueryHandler extends PEPCommandHandler {
 			
 			// A valid request is an IQ of type get, for a valid and local recipient
 			if (!(packet.getType().equals(IQ.Type.get) && target != null && target.getNode() != null 
-					&& userManager.isRegisteredUser(target.getNode()))) {
+					&& userManager.isRegisteredUser(target, false))) {
 				IQ result = IQ.createResultIQ(packet);
 				result.setChildElement(packet.getChildElement().createCopy());
 				result.setError(PacketError.Condition.bad_request);

--- a/src/java/org/onesocialweb/openfire/handler/activity/ActivitySubscribeHandler.java
+++ b/src/java/org/onesocialweb/openfire/handler/activity/ActivitySubscribeHandler.java
@@ -60,7 +60,7 @@ public class ActivitySubscribeHandler extends PEPCommandHandler {
 			
 			// A valid request is an IQ of type set, for a valid and local recipient
 			if (!(packet.getType().equals(IQ.Type.set) && recipient != null && recipient.getNode() != null 
-					&& userManager.isRegisteredUser(recipient.getNode()))) {
+					&& userManager.isRegisteredUser(recipient, false))) {
 				IQ result = IQ.createResultIQ(packet);
 				result.setChildElement(packet.getChildElement().createCopy());
 				result.setError(PacketError.Condition.bad_request);

--- a/src/java/org/onesocialweb/openfire/handler/activity/ActivitySubscribersHandler.java
+++ b/src/java/org/onesocialweb/openfire/handler/activity/ActivitySubscribersHandler.java
@@ -67,7 +67,7 @@ public class ActivitySubscribersHandler extends PEPCommandHandler {
 			
 			// A valid request is an IQ of type get, for a valid and local recipient
 			if (!(packet.getType().equals(IQ.Type.get) && recipient != null && recipient.getNode() != null 
-					&& userManager.isRegisteredUser(recipient.getNode()))) {
+					&& userManager.isRegisteredUser(recipient, false))) {
 				IQ result = IQ.createResultIQ(packet);
 				result.setChildElement(packet.getChildElement().createCopy());
 				result.setError(PacketError.Condition.bad_request);

--- a/src/java/org/onesocialweb/openfire/handler/activity/ActivitySubscriptionsHandler.java
+++ b/src/java/org/onesocialweb/openfire/handler/activity/ActivitySubscriptionsHandler.java
@@ -68,7 +68,7 @@ public class ActivitySubscriptionsHandler extends PEPCommandHandler {
 			
 			// A valid request is an IQ of type get, for a valid and local recipient
 			if (!(packet.getType().equals(IQ.Type.get) && recipient != null && recipient.getNode() != null 
-					&& userManager.isRegisteredUser(recipient.getNode()))) {
+					&& userManager.isRegisteredUser(recipient, false))) {
 				IQ result = IQ.createResultIQ(packet);
 				result.setChildElement(packet.getChildElement().createCopy());
 				result.setError(PacketError.Condition.bad_request);

--- a/src/java/org/onesocialweb/openfire/handler/activity/ActivityUnsubscribeHandler.java
+++ b/src/java/org/onesocialweb/openfire/handler/activity/ActivityUnsubscribeHandler.java
@@ -60,7 +60,7 @@ public class ActivityUnsubscribeHandler extends PEPCommandHandler {
 			
 			// A valid request is an IQ of type set, for a valid and local recipient
 			if (!(packet.getType().equals(IQ.Type.set) && recipient != null && recipient.getNode() != null 
-					&& userManager.isRegisteredUser(recipient.getNode()))) {
+					&& userManager.isRegisteredUser(recipient, false))) {
 				IQ result = IQ.createResultIQ(packet);
 				result.setChildElement(packet.getChildElement().createCopy());
 				result.setError(PacketError.Condition.bad_request);

--- a/src/java/org/onesocialweb/openfire/handler/commenting/CommentPublishHandler.java
+++ b/src/java/org/onesocialweb/openfire/handler/commenting/CommentPublishHandler.java
@@ -68,7 +68,7 @@ public class CommentPublishHandler extends PEPCommandHandler  {
 			}
 			
 			// Only a local user can publish an activity to his stream
-			if (!userManager.isRegisteredUser(sender.getNode())) {
+			if (!userManager.isRegisteredUser(sender, false)) {
 				IQ result = IQ.createResultIQ(packet);
 				result.setChildElement(packet.getChildElement().createCopy());
 				result.setError(PacketError.Condition.not_authorized);

--- a/src/java/org/onesocialweb/openfire/handler/inbox/InboxQueryHandler.java
+++ b/src/java/org/onesocialweb/openfire/handler/inbox/InboxQueryHandler.java
@@ -83,7 +83,7 @@ public class InboxQueryHandler extends PEPCommandHandler {
 			}
 
 			// Only a local user has an inbox
-			if (!userManager.isRegisteredUser(sender.getNode())) {
+			if (!userManager.isRegisteredUser(sender, false)) {
 				IQ result = IQ.createResultIQ(packet);
 				result.setChildElement(packet.getChildElement().createCopy());
 				result.setError(PacketError.Condition.not_authorized);

--- a/src/java/org/onesocialweb/openfire/handler/profile/IQProfilePublishHandler.java
+++ b/src/java/org/onesocialweb/openfire/handler/profile/IQProfilePublishHandler.java
@@ -81,7 +81,7 @@ public class IQProfilePublishHandler extends IQHandler {
 			}
 			
 			// Only a local user can publish its profile
-			if (!userManager.isRegisteredUser(sender.getNode())) {
+			if (!userManager.isRegisteredUser(sender, false)) {
 				IQ result = IQ.createResultIQ(packet);
 				result.setChildElement(packet.getChildElement().createCopy());
 				result.setError(PacketError.Condition.not_authorized);

--- a/src/java/org/onesocialweb/openfire/handler/profile/IQProfileQueryHandler.java
+++ b/src/java/org/onesocialweb/openfire/handler/profile/IQProfileQueryHandler.java
@@ -72,7 +72,7 @@ public class IQProfileQueryHandler extends IQHandler {
 			
 			// A valid request is an IQ of type get, for a valid and local recipient
 			if (!(packet.getType().equals(IQ.Type.get) && target != null && target.getNode() != null 
-					&& userManager.isRegisteredUser(target.getNode()))) {
+					&& userManager.isRegisteredUser(target, false))) {
 				IQ result = IQ.createResultIQ(packet);
 				result.setChildElement(packet.getChildElement().createCopy());
 				result.setError(PacketError.Condition.bad_request);

--- a/src/java/org/onesocialweb/openfire/handler/relation/IQRelationQueryHandler.java
+++ b/src/java/org/onesocialweb/openfire/handler/relation/IQRelationQueryHandler.java
@@ -73,7 +73,7 @@ public class IQRelationQueryHandler extends IQHandler {
 			
 			// A valid request is an IQ of type get, for a valid and local recipient
 			if (!(packet.getType().equals(IQ.Type.get) && target != null && target.getNode() != null 
-					&& userManager.isRegisteredUser(target.getNode()))) {
+					&& userManager.isRegisteredUser(target, false))) {
 				IQ result = IQ.createResultIQ(packet);
 				result.setChildElement(packet.getChildElement().createCopy());
 				result.setError(PacketError.Condition.bad_request);

--- a/src/java/org/onesocialweb/openfire/handler/relation/IQRelationSetupHandler.java
+++ b/src/java/org/onesocialweb/openfire/handler/relation/IQRelationSetupHandler.java
@@ -89,7 +89,7 @@ public class IQRelationSetupHandler extends IQHandler {
 			}
 			
 			// Only a local user can publish an activity to his stream
-			if (!userManager.isRegisteredUser(sender.getNode())) {
+			if (!userManager.isRegisteredUser(sender, false)) {
 				IQ result = IQ.createResultIQ(packet);
 				result.setChildElement(packet.getChildElement().createCopy());
 				result.setError(PacketError.Condition.not_authorized);

--- a/src/java/org/onesocialweb/openfire/handler/relation/IQRelationUpdateHandler.java
+++ b/src/java/org/onesocialweb/openfire/handler/relation/IQRelationUpdateHandler.java
@@ -72,7 +72,7 @@ public class IQRelationUpdateHandler extends IQHandler {
 		try {
 
 			// Only a local user can request to update a relation
-			if (!userManager.isRegisteredUser(sender.getNode())) {
+			if (!userManager.isRegisteredUser(sender, false)) {
 				IQ result = IQ.createResultIQ(packet);
 				result.setChildElement(packet.getChildElement().createCopy());
 				result.setError(PacketError.Condition.not_authorized);

--- a/src/java/org/onesocialweb/openfire/web/SessionValidator.java
+++ b/src/java/org/onesocialweb/openfire/web/SessionValidator.java
@@ -53,7 +53,7 @@ public class SessionValidator {
 		}
 		
 		// Is the session authenticated ?
-		if (session.getStatus() != Session.STATUS_AUTHENTICATED) {
+		if (session.getStatus() != Session.Status.AUTHENTICATED) {
 			return false;
 		}
 


### PR DESCRIPTION
Replaced Openfire API usage that was deprecated in Openfire 4.8.0 and removed in 4.9.0.

This plugin is now compatible with Openfire 4.9.0 and requires 4.8.0 or later. No longer compatible with versions older than 4.8.0.

fixes #2